### PR TITLE
Vjw/references et cetera grid

### DIFF
--- a/src/tabbed-form.css
+++ b/src/tabbed-form.css
@@ -69,6 +69,8 @@
 /* tab content area */
 .tab-content-panel {
   background-color: rgb(132, 173, 208);
+  border-bottom-left-radius: 0.5rem;
+  border-bottom-right-radius: 0.5rem;
   padding: 1rem;
 }
 
@@ -80,6 +82,18 @@
 .tab-content-footer {
   display: flex;
   justify-content: flex-end;
+}
+
+.rvf .tab-content-footer .submit-button {
+  display: flex;
+  justify-content: flex-end;
+  width: auto;
+}
+
+.rvf .tab-content-footer .submit-button button {
+  font-size: 1.25rem;
+  font-weight: 500;
+  padding: 0.5rem 1rem;
 }
 
 .tab-content.inactive-tab {
@@ -200,6 +214,14 @@
 
 #references .tabbed-fieldset .grid-group .quad-width {
   grid-area: span 1 / span 4;
+}
+#volunteer-agreement .tabbed-fieldset .grid-group {
+  display: grid;
+  grid-gap: 1rem;
+  grid-template-columns: 1fr 1fr;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  padding-bottom: 1rem;
 }
 
 .tabbed-fieldset .first-two-columns {

--- a/src/volunteer-form-tabbed.html
+++ b/src/volunteer-form-tabbed.html
@@ -923,38 +923,43 @@
                                 </li>
                             </ul>
 
-                            <p><strong>I have read and agree to the terms stated above.</strong></p>
-
-                            <div class="rtv-form-group">
-                                <label for="00Nj0000002TZHs">Volunteer Signature</label>
-                                <input id="00Nj0000002TZHs" maxlength="200" name="00Nj0000002TZHs" type="text" />
-                                <p class="input-help">(Please type your name.)</p>
+                            <div class="rtv-form-group flex">
+                                <input id="putRealFieldIDhere" name="putRealFieldIDhere" type="checkbox" value="1" />
+                                <label class="checkbox-label" for="putRealFieldIDhere">I have read and agree to the terms stated above.</label>
                             </div>
 
-                            <div class="rtv-form-group">
-                                <label for="00Nj0000002TZFc">How did you hear about Refugee & Immigrant Transitions?</label>
-                                <select id="00Nj0000002TZFc" title="Referral Source" multiple="multiple" name="00Nj0000002TZFc">
-                                    <option value="Website">Website</option>
-                                    <option value="Online Posting">Online Posting</option>
-                                    <option value="Employer">Employer</option>
-                                    <option value="TV/Radio">TV/Radio</option>
-                                    <option value="Friend">Friend</option>
-                                    <option value="Newspaper">Newspaper</option>
-                                    <option value="Volunteer Center">Volunteer Center</option>
-                                    <option value="Peace Corp">Peace Corp</option>
-                                    <option value="Library/Project Read">Library/Project Read</option>
-                                    <option value="Universities/Schools">Universities/Schools</option>
-                                    <option value="Other">Other</option>
-                                    <option value="RT Staff/Volunteer/Board Member">RIT Staff/Volunteer/Board Member</option>
-                                    <option value="Flier">Flier</option>
-                                </select>
-                                <p class="input-help">(Please select all that apply. Press Ctrl on Windows or Command on MacOS and click if
-                                    choosing more than one option.)</p>
-                            </div>
+                            <div class="grid-group">
+                                <div class="rtv-form-group">
+                                    <label for="00Nj0000002TZHs">Volunteer Signature</label>
+                                    <input id="00Nj0000002TZHs" maxlength="200" name="00Nj0000002TZHs" type="text" />
+                                    <p class="input-help">(Please type your name.)</p>
+                                </div>
 
-                            <div class="rtv-form-group">
-                                <label for="00Nj0000002TXZh">If you were referred to RIT by another source, please specify.</label>
-                                <input id="00Nj0000002TXZh" maxlength="200" name="00Nj0000002TXZh" type="text" />
+                                <div class="rtv-form-group">
+                                    <label for="00Nj0000002TZFc">How did you hear about Refugee & Immigrant Transitions?</label>
+                                    <select id="00Nj0000002TZFc" title="Referral Source" multiple="multiple" name="00Nj0000002TZFc">
+                                        <option value="Website">Website</option>
+                                        <option value="Online Posting">Online Posting</option>
+                                        <option value="Employer">Employer</option>
+                                        <option value="TV/Radio">TV/Radio</option>
+                                        <option value="Friend">Friend</option>
+                                        <option value="Newspaper">Newspaper</option>
+                                        <option value="Volunteer Center">Volunteer Center</option>
+                                        <option value="Peace Corp">Peace Corp</option>
+                                        <option value="Library/Project Read">Library/Project Read</option>
+                                        <option value="Universities/Schools">Universities/Schools</option>
+                                        <option value="Other">Other</option>
+                                        <option value="RT Staff/Volunteer/Board Member">RIT Staff/Volunteer/Board Member</option>
+                                        <option value="Flier">Flier</option>
+                                    </select>
+                                    <p class="input-help">(Please select all that apply. Press Ctrl on Windows or Command on MacOS and click if
+                                        choosing more than one option.)</p>
+                                </div>
+
+                                <div class="rtv-form-group">
+                                    <label for="00Nj0000002TXZh">If you were referred to RIT by another source, please specify.</label>
+                                    <input id="00Nj0000002TXZh" maxlength="200" name="00Nj0000002TXZh" type="text" />
+                                </div>
                             </div>
                         </fieldset>
                         <div class="tab-content-footer">


### PR DESCRIPTION
I let the all-in-one Address field expand to fill 4 of the five columns, because if I've got to type a whole address in one field, I hate for it to scroll. (Easy to match spanning only 3/5 columns like the mocks if necessary.)

<img width="1238" alt="Screen Shot 2021-10-28 at 9 59 50 AM" src="https://user-images.githubusercontent.com/715729/139271610-6f5a44fa-029b-4ee1-bce6-d6304b603c60.png">
